### PR TITLE
refactor(connectStore): do not rely in update and connect calling order

### DIFF
--- a/src/modules/rcast/store/wire-adapter.js
+++ b/src/modules/rcast/store/wire-adapter.js
@@ -2,27 +2,43 @@ export class connectStore {
     dataCallback;
     store;
     subscription;
+    connected = false;
 
     constructor(dataCallback) {
         this.dataCallback = dataCallback;
     }
 
     connect() {
-        const notifyStateChange = () => {
-            const state = this.store.getState();
-            this.dataCallback(state);
-        };
-        this.subscription = this.store.subscribe(notifyStateChange);
-        notifyStateChange();
+        this.connected = true;
+        this.subscribeToStore();
     }
 
     disconnect() {
-        if (this.subscription) {
-            this.subscription();
-        }
+        this.unsubscribeFromStore();
+        this.connected = false;
     }
 
     update(config) {
+        this.unsubscribeFromStore();
         this.store = config.store;
+        this.subscribeToStore();
+    }
+
+    subscribeToStore() {
+        if (this.connected && this.store) {
+            const notifyStateChange = () => {
+                const state = this.store.getState();
+                this.dataCallback(state);
+            };
+            this.subscription = this.store.subscribe(notifyStateChange);
+            notifyStateChange();
+        }
+    }
+
+    unsubscribeFromStore() {
+        if (this.subscription) {
+            this.subscription();
+            this.subscription = undefined;
+        }
     }
 }


### PR DESCRIPTION
This pr refactor the `connectStore` to account for:
1. with lwc wire protocol, you can't rely on the order in which `update` and `connect` are called.
2. the `update` method of the `connectStore` wire adapter may be called multiple times (if the store is changed on the component).